### PR TITLE
feat: improve Shadow DOM compatibility

### DIFF
--- a/design-library/src/tokens/plugin/tailwindPlugin.ts
+++ b/design-library/src/tokens/plugin/tailwindPlugin.ts
@@ -5,7 +5,7 @@ import formsPlugin from "@tailwindcss/forms";
 const tailwindPlugin = function ({ addBase, addComponents, theme }: any) {
   for (const [variableName, variableValue] of Object.entries(globalCssVariables)) {
     addBase({
-      ":root": {
+      ":root, :host": {
         [variableName]: variableValue,
       },
     });


### PR DESCRIPTION
# Change summary

Add `:host` to make library compatible with Shadow DOM. This was also done in `tailwindcss` recently:
https://github.com/tailwindlabs/tailwindcss/pull/11200

## Change type

-   [ ] No review
-   [x] Small PR
-   [ ] Big PR
-   [ ] Refactor

Regarding:
https://github.com/bcc-code/bcc-platform/issues/122
