### PR TITLE
fix: modal for mobile

### DIFF
--- a/design-library/src/components/BccModal/BccModal.vue
+++ b/design-library/src/components/BccModal/BccModal.vue
@@ -29,7 +29,7 @@ const showCloseButton = computed(() => props.closeButton && !slots.header);
 <template>
   <TransitionRoot as="template" :show="open">
     <Dialog as="div" class="bcc-modal-overlay-wrapper" @close="emit('close')">
-      <div class="flex h-screen w-screen items-center justify-center overflow-hidden">
+      <div class="flex h-[100dvh] w-[100dvw] items-center justify-center overflow-hidden">
         <TransitionChild
           as="div"
           enter="ease-out duration-300"

--- a/design-library/src/components/BccModal/__snapshots__/BccModal.spec.ts.snap
+++ b/design-library/src/components/BccModal/__snapshots__/BccModal.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`BccModal > renders a modal 1`] = `
 "<anonymous-stub as=\\"template\\" show=\\"true\\" unmount=\\"true\\" appear=\\"false\\" enter=\\"\\" enterfrom=\\"\\" enterto=\\"\\" entered=\\"\\" leave=\\"\\" leavefrom=\\"\\" leaveto=\\"\\">
   <dialog-stub as=\\"div\\" static=\\"false\\" unmount=\\"true\\" open=\\"DC8F892D-2EBD-447C-A4C8-A03058436FF4\\" id=\\"headlessui-dialog-1\\" class=\\"bcc-modal-overlay-wrapper\\">
-    <div class=\\"flex h-screen w-screen items-center justify-center overflow-hidden\\">
+    <div class=\\"flex h-[100dvh] w-[100dvw] items-center justify-center overflow-hidden\\">
       <anonymous-stub as=\\"div\\" unmount=\\"true\\" appear=\\"false\\" enter=\\"ease-out duration-300\\" enterfrom=\\"opacity-0\\" enterto=\\"opacity-100\\" entered=\\"\\" leave=\\"ease-in duration-200\\" leavefrom=\\"opacity-100\\" leaveto=\\"opacity-0\\">
         <div class=\\"bcc-modal-overlay\\"></div>
       </anonymous-stub>


### PR DESCRIPTION
# Change summary

use 100dvw and 100dvh instead of w-screen and h-screen

Without this, the dialog will overflow on mobile browser, because they dynamically display navigation bar when users scroll up/down. "w-screen" and "h-screen" (vw, vh) don't react correctly to this.

## Change type

-   [ ] No review
-   [x] Small PR
-   [ ] Big PR
-   [ ] Refactor
