### PR TITLE
Fix BccProgress component not exported from TS

### DIFF
--- a/design-library/src/index.ts
+++ b/design-library/src/index.ts
@@ -30,3 +30,4 @@ export { default as BccTabs } from "./components/BccTabs/BccTabs.vue";
 export { default as BccToggle } from "./components/BccToggle/BccToggle.vue";
 export { default as BccBanner } from "./components/BccBanner/BccBanner.vue";
 export { default as BccSpinner } from "./components/BccSpinner/BccSpinner.vue";
+export { default as BccProgress } from "./components/BccProgress/BccProgress.vue";


### PR DESCRIPTION
This was forgotten when creating: https://github.com/bcc-code/bcc-design/commit/a04bda910a30a5b5afc106e3114429258dfed094

For future reference, using the `pnpm create-component` command ensures all required files are updated.
