### PR TITLE
Export types from table component

### DIFF
--- a/design-library/src/components/BccReact/BccReactEmoji.vue
+++ b/design-library/src/components/BccReact/BccReactEmoji.vue
@@ -1,12 +1,15 @@
-<script setup lang="ts">
-import { ref, watch } from "vue";
-
+<script lang="ts">
 export type EmojiStat = {
   id: string;
   emoji: string;
   count?: number;
   selected?: boolean;
 };
+</script>
+
+<script setup lang="ts">
+import { ref, watch } from "vue";
+
 const props = defineProps<EmojiStat>();
 
 const animate = ref(false);

--- a/design-library/src/components/BccTable/BccTable.vue
+++ b/design-library/src/components/BccTable/BccTable.vue
@@ -1,15 +1,17 @@
-<script setup lang="ts">
-import { SwapVertIcon, ArrowUpwardIcon, ArrowDownwardIcon } from "@bcc-code/icons-vue";
-import { computed, toRefs } from "vue";
-
-type Column = {
+<script lang="ts">
+export type Column = {
   key: string;
   text?: string;
   sortable?: boolean;
   sortMethod?: (a: Item, b: Item) => number;
 };
-type Item = Record<string, any>;
-type SortDirection = "ascending" | "descending";
+export type Item = Record<string, any>;
+export type SortDirection = "ascending" | "descending";
+</script>
+
+<script setup lang="ts">
+import { SwapVertIcon, ArrowUpwardIcon, ArrowDownwardIcon } from "@bcc-code/icons-vue";
+import { computed, toRefs } from "vue";
 
 type Props = {
   columns: Column[];


### PR DESCRIPTION
As they weren't exported before they couldn't be used outside the component, leading to possible type errors.

Additionally, moved the export for emoji to non-setup as well which seems to be the proper place.