### PR TITLE
change default auth method for documentation on developer.bcc.no to bcc-login

### DIFF
--- a/.github/workflows/build-and-deploy-documentation.yml
+++ b/.github/workflows/build-and-deploy-documentation.yml
@@ -30,3 +30,4 @@ jobs:
         with:
           title: BCC Design System
           description: Technical documentation and guides to facilitate the correct use of design assets of BCC
+          authentication: 'portal'


### PR DESCRIPTION
change default auth method for documentation on developer.bcc.no to bcc-login

# Change summary

## Change type

-   [X] No review
-   [ ] Small PR
-   [ ] Big PR
-   [ ] Refactor

**Closes #ISSUE_NUMBER** _or_ **Part of #ISSUE_NUMBER**
