### PR TITLE
feat(table): use generics to infer type of item

### DIFF
--- a/design-library/src/components/BccTable/BccTable.vue
+++ b/design-library/src/components/BccTable/BccTable.vue
@@ -9,13 +9,13 @@ export type Item = Record<string, any>;
 export type SortDirection = "ascending" | "descending";
 </script>
 
-<script setup lang="ts">
+<script setup lang="ts" generic="TItem extends Item">
 import { SwapVertIcon, ArrowUpwardIcon, ArrowDownwardIcon } from "@bcc-code/icons-vue";
 import { computed, toRefs } from "vue";
 
 type Props = {
   columns: Column[];
-  items: Item[];
+  items: TItem[];
   sortBy?: string;
   sortDirection?: SortDirection;
 };
@@ -27,7 +27,7 @@ const { columns, items, sortBy, sortDirection } = toRefs(props);
 
 const emit = defineEmits(["update:sortBy", "update:sortDirection"]);
 
-function getField(item: Item, columnKey: string) {
+function getField(item: TItem, columnKey: string) {
   const segments = columnKey.split(".");
   return segments.reduce((obj, key) => obj[key], item);
 }


### PR DESCRIPTION
# Change summary

A small change to how `BccTable` is typed; specifically the `items`.

[Vue 3.3 introduced generics](https://blog.vuejs.org/posts/vue-3-3#generic-components), which greatly improves the potential DX for components such as tables.
By using a generic type parameter like this, we eg. get autocomplete for the `item` slot props.

We could probably implement this in other components as well.

## Change type

-   [ ] No review
-   [x] Small PR
-   [ ] Big PR
-   [ ] Refactor
