### PR TITLE
fix: adjust emoji buttons sizes and selector shadow on safari

### DIFF
--- a/design-library/src/components/BccReact/BccReact.css
+++ b/design-library/src/components/BccReact/BccReact.css
@@ -22,7 +22,7 @@
   }
 
   .bcc-react-selector {
-    @apply flex h-9 flex-col overflow-hidden bg-neutral-100 px-0 drop-shadow-md;
+    @apply flex h-9 flex-col overflow-hidden bg-neutral-100 px-0 shadow-md;
     border-radius: 18px;
   }
 
@@ -58,8 +58,7 @@
   }
 
   .bcc-react-selector-item {
-    @apply p-2 text-xl leading-none transition-transform duration-200 ease-out;
-    position: relative;
+    @apply p-2 text-xl leading-none transition-transform duration-200 ease-out h-9 w-9 relative;
   }
 
   .bcc-react-selector-item--clicked {


### PR DESCRIPTION
# Change summary
Two issues fixed for safarI:
- Emoji button's unfixed sizes force the button's to wrap;
- Selector's shadow doesn't look ok.

**before:**
<img width="334" height="145" alt="image" src="https://github.com/user-attachments/assets/64acc679-32f9-44b3-8640-c455f0d6d5a0" />

 **after:**
  <img width="334" height="137" alt="image" src="https://github.com/user-attachments/assets/25efc911-e0f5-481b-8837-0bae78568e1e" />
  
  




## Change type

-   [ ] No review
-   [X] Small PR
-   [ ] Big PR
-   [ ] Refactor

**Closes #ISSUE_NUMBER** _or_ **Part of #ISSUE_NUMBER**
