### PR TITLE
fix: based on the design for large button icon should be 20px

### DIFF
--- a/component-library/src/components/wrapped/BccButton.vue
+++ b/component-library/src/components/wrapped/BccButton.vue
@@ -32,24 +32,16 @@ const buttonBindings = computed((): PrimeButtonProps => {
 <template>
 	<PrimeButton v-bind="buttonBindings" :class="{ useCtx }" class="shrink-0">
 		<template #icon>
-			<component
-				:is="icon"
-				class="shrink-0"
-				:class="[iconClass, { 'order-1': iconRight === true }, size === 'large' ? 'size-6' : 'size-5']"
-			/>
+			<component :is="icon" class="shrink-0" :class="[iconClass, { 'order-1': iconRight === true }, 'size-5']" />
 			<component
 				:is="iconRight"
 				v-if="typeof iconRight !== 'boolean'"
 				class="order-last shrink-0"
-				:class="[iconClass, size === 'large' ? 'size-6' : 'size-5']"
+				:class="[iconClass, 'size-5']"
 			/>
 		</template>
 		<template #loadingicon>
-			<component
-				:is="loadingIcon"
-				class="shrink-0"
-				:class="[iconClass, { 'order-1': iconRight === true }, size === 'large' ? 'size-6' : 'size-5']"
-			/>
+			<component :is="loadingIcon" class="shrink-0" :class="[iconClass, { 'order-1': iconRight === true }, 'size-5']" />
 		</template>
 		<slot />
 	</PrimeButton>


### PR DESCRIPTION
# Change summary
for large button icon should be 20px
https://www.figma.com/design/x7vsnjXR7gEpVkcpcNJj9K/BCC-Prime-Components-2.0?node-id=7596-35989&t=qTW8VGtlogwOrwHZ-1
<img width="475" height="713" alt="image" src="https://github.com/user-attachments/assets/1673eb4c-0151-4f1f-ad03-fa085b1f71d4" />


## Change type

-   [ ] No review
-   [X] Small PR
-   [ ] Big PR
-   [ ] Refactor

**Closes #ISSUE_NUMBER** _or_ **Part of #ISSUE_NUMBER**
